### PR TITLE
Let background ghost slots hide when their parent slot has an item

### DIFF
--- a/src/main/java/com/enderio/core/client/gui/widget/GhostBackgroundItemSlot.java
+++ b/src/main/java/com/enderio/core/client/gui/widget/GhostBackgroundItemSlot.java
@@ -60,7 +60,7 @@ public class GhostBackgroundItemSlot extends GhostSlot {
 
   @Override
   public boolean isVisible() {
-    return parent != null ? parent.xDisplayPosition >= 0 && parent.yDisplayPosition >= 0 : super.isVisible();
+    return parent != null ? parent.xDisplayPosition >= 0 && parent.yDisplayPosition >= 0 && !parent.getHasStack() && super.isVisible() : super.isVisible();
   }
 
 }


### PR DESCRIPTION
also honour inherited visible flag even when a parent is set