### PR TITLE
Fix several classloading and transformation issues

### DIFF
--- a/src/main/java/com/enderio/core/common/transform/EnderCoreTransformer.java
+++ b/src/main/java/com/enderio/core/common/transform/EnderCoreTransformer.java
@@ -39,11 +39,11 @@ public class EnderCoreTransformer implements IClassTransformer {
   // (in this case, a state event), the referenced event class is
   // loaded along with the containing class of the method.
   // Since EnderCore is referenced in the 'transform' method of this class,
-  // the aforementioned event classes are consequently referenced and classloaded too early.
+  // EnderCore and the aforementioned event classes are consequently referenced and classloaded too early.
   //
   // In order to be compatible with coremods such as Sponge, FML event
   // classes cannot be classloaded until the game is starting. Specifically,
-  // there are being loaded before FML is ready to actually start posting state events.
+  // they are being classloaded before FML is ready to actually start posting state events.
   // This is significantly earlier than certain coremods such as Sponge expect,
   // which prevents them from properly applying their own transformations.
 


### PR DESCRIPTION
`EnderCoreTransformer` is causing several classes to be loaded earlier than they should be. While this is normally not a problem, the [SpongeForge](https://github.com/SpongePowered/SpongeForge) mod is experiencing [an issue due to this](https://github.com/SpongePowered/SpongeForge/issues/610).

I've provided a more thorough explanation in the form of comments within the PR, but the root of the issue is that `EnderCore` class is being referenced from the transformer (through a reference to the static `logger` field).

This PR removes the reference to `EnderCore` in `EnderCoreTransformer` by copying over the `logger` field. Unfortunately, the `EnderCore.NAME` field cannot be used for the same reason that the `logger` field cannot. However, I can abstract that out to a separate class if necessary.

I've also added some transformer exclusions for classes loaded directly and indirectly by `EnderCoreTransformer`. This is less of an issue than the `EnderCore` reference, but will prevent any future compatibility issues with [SpongeForge](https://github.com/SpongePowered/SpongeForge) or other [Mixin](https://github.com/SpongePowered/Mixin)-based projects.
