### PR TITLE
Add Right Click Harvest/Replant to Beetroot

### DIFF
--- a/src/main/resources/assets/endercore/config/cropConfig.json
+++ b/src/main/resources/assets/endercore/config/cropConfig.json
@@ -1,6 +1,6 @@
 {"data":
 	[
-		{
+	{
             "seed":"minecraft:wheat_seeds",
             "block":"minecraft:wheat"
         },
@@ -12,10 +12,10 @@
             "seed":"minecraft:potato",
             "block":"minecraft:potatoes"
         },
-		{
+        {
             "seed":"minecraft:beetroot_seeds",
             "block":"minecraft:beetroots",
-			"meta":3
+            "meta":3
         },
         {
             "seed":"minecraft:nether_wart",

--- a/src/main/resources/assets/endercore/config/cropConfig.json
+++ b/src/main/resources/assets/endercore/config/cropConfig.json
@@ -12,6 +12,11 @@
             "seed":"minecraft:potato",
             "block":"minecraft:potatoes"
         },
+       	{
+            "seed":"minecraft:beetroot_seeds",
+            "block":"minecraft:beetroots",
+            "meta":3
+        },
         {
             "seed":"minecraft:nether_wart",
             "block":"minecraft:nether_wart",

--- a/src/main/resources/assets/endercore/config/cropConfig.json
+++ b/src/main/resources/assets/endercore/config/cropConfig.json
@@ -12,10 +12,10 @@
             "seed":"minecraft:potato",
             "block":"minecraft:potatoes"
         },
-       	{
+		{
             "seed":"minecraft:beetroot_seeds",
             "block":"minecraft:beetroots",
-            "meta":3
+			"meta":3
         },
         {
             "seed":"minecraft:nether_wart",


### PR DESCRIPTION
This is the config file I'm using to add the Right Click Harvest ability to Vanilla Beetroot in 1.10.  This may be applicable to the 1.9 branch(es) as well.