### PR TITLE
Fix binding block texture instead of glint texture

### DIFF
--- a/src/main/java/com/enderio/core/client/render/RenderUtil.java
+++ b/src/main/java/com/enderio/core/client/render/RenderUtil.java
@@ -158,7 +158,7 @@ public class RenderUtil {
   }
 
   public static void bindGlintTexture() {
-    engine().bindTexture(BLOCK_TEX);
+    engine().bindTexture(GLINT_TEX);
   }
 
   public static void bindTexture(String string) {


### PR DESCRIPTION
This probably isn't used anywhere, but worth a fix anyway.