### PR TITLE
The singleton Scheduler's task list needs to be thread safe.

### DIFF
--- a/src/main/java/com/enderio/core/common/util/Scheduler.java
+++ b/src/main/java/com/enderio/core/common/util/Scheduler.java
@@ -1,6 +1,7 @@
 package com.enderio.core.common.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class Scheduler {
     }
   }
 
-  private final List<Task> tasks = new ArrayList<Task>();
+  private final List<Task> tasks = Collections.synchronizedList(new ArrayList<Task>());
 
   /**
    * Schedules a task to be called later


### PR DESCRIPTION
Since user action events can happen at the same time as scheduled tasks
may fire, we get CMEs when one adds to the list while the other removes
from it and iterates it.

Minor performance penalty, but not user detectable.