### PR TITLE
Added the ability to move the config overlay right boundary

### DIFF
--- a/src/main/java/com/enderio/core/api/client/gui/IGuiScreen.java
+++ b/src/main/java/com/enderio/core/api/client/gui/IGuiScreen.java
@@ -30,7 +30,9 @@ public interface IGuiScreen {
 
   void removeButton(@Nonnull GuiButton button);
 
-  int getOverlayOffsetX();
+  int getOverlayOffsetXLeft();
+
+  int getOverlayOffsetXRight();
 
   void doActionPerformed(@Nonnull GuiButton but) throws IOException;
 

--- a/src/main/java/com/enderio/core/client/gui/GuiContainerBase.java
+++ b/src/main/java/com/enderio/core/client/gui/GuiContainerBase.java
@@ -500,7 +500,12 @@ public abstract class GuiContainerBase extends GuiContainer implements ToolTipRe
   }
 
   @Override
-  public int getOverlayOffsetX() {
+  public int getOverlayOffsetXLeft() {
+    return 0;
+  }
+
+  @Override
+  public int getOverlayOffsetXRight() {
     return 0;
   }
 

--- a/src/main/java/com/enderio/core/client/gui/GuiScreenBase.java
+++ b/src/main/java/com/enderio/core/client/gui/GuiScreenBase.java
@@ -152,7 +152,12 @@ public abstract class GuiScreenBase extends GuiScreen implements ToolTipRenderer
   }
 
   @Override
-  public int getOverlayOffsetX() {
+  public int getOverlayOffsetXLeft() {
+    return 0;
+  }
+
+  @Override
+  public int getOverlayOffsetXRight() {
     return 0;
   }
 


### PR DESCRIPTION
Useful for centring the overlay on containers that are strangely shaped (e.g. wired charger and dim trans)