### PR TITLE
Update mappings to final 1.12 mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ if (project.hasProperty('mod_appendix')) {
 }
 
 minecraft {
-    mappings = "snapshot_20171212"
+    mappings = "stable_39"
     version = "${minecraft_version}-${forge_version}"
     runDir = 'run'
 

--- a/src/main/java/com/enderio/core/client/handlers/SpecialTooltipHandler.java
+++ b/src/main/java/com/enderio/core/client/handlers/SpecialTooltipHandler.java
@@ -228,7 +228,7 @@ public class SpecialTooltipHandler {
       unlocalizedNameForTooltip = ((IResourceTooltipProvider) itemstack.getItem()).getUnlocalizedNameForTooltip(itemstack);
     }
     if (unlocalizedNameForTooltip == null) {
-      unlocalizedNameForTooltip = itemstack.getItem().getUnlocalizedName(itemstack);
+      unlocalizedNameForTooltip = itemstack.getItem().getTranslationKey(itemstack);
     }
     return unlocalizedNameForTooltip;
   }

--- a/src/main/java/com/enderio/core/client/render/RenderUtil.java
+++ b/src/main/java/com/enderio/core/client/render/RenderUtil.java
@@ -180,7 +180,7 @@ public class RenderUtil {
     if (face == EnumFacing.DOWN) {
       return 0.5f;
     }
-    if (face.getFrontOffsetX() != 0) {
+    if (face.getXOffset() != 0) {
       return 0.6f;
     }
     return 0.8f; // z
@@ -262,13 +262,13 @@ public class RenderUtil {
    */
   public static List<EnumFacing> getEdgesForFace(@Nonnull EnumFacing face) {
     List<EnumFacing> result = new ArrayList<EnumFacing>(4);
-    if (face.getFrontOffsetY() != 0) {
+    if (face.getYOffset() != 0) {
       result.add(NORTH);
       result.add(EAST);
       result.add(SOUTH);
       result.add(WEST);
 
-    } else if (face.getFrontOffsetX() != 0) {
+    } else if (face.getXOffset() != 0) {
       result.add(DOWN);
       result.add(SOUTH);
       result.add(UP);

--- a/src/main/java/com/enderio/core/client/render/VertexRotationFacing.java
+++ b/src/main/java/com/enderio/core/client/render/VertexRotationFacing.java
@@ -31,7 +31,7 @@ public class VertexRotationFacing extends VertexRotation {
   }
 
   public EnumFacing rotate(@Nonnull EnumFacing dir) {
-    if (dir.getFrontOffsetY() != 0) {
+    if (dir.getYOffset() != 0) {
       return dir;
     }
     if (getAngle() == ROTATION_AMOUNT) {

--- a/src/main/java/com/enderio/core/common/TileEntityBase.java
+++ b/src/main/java/com/enderio/core/common/TileEntityBase.java
@@ -154,7 +154,7 @@ public abstract class TileEntityBase extends TileEntity implements ITickable {
   protected void writeCustomNBT(@Nonnull ItemStack stack) {
     final NBTTagCompound tag = new NBTTagCompound();
     writeCustomNBT(NBTAction.ITEM, tag);
-    if (!tag.hasNoTags()) {
+    if (!tag.isEmpty()) {
       stack.setTagCompound(tag);
     }
   }
@@ -183,7 +183,7 @@ public abstract class TileEntityBase extends TileEntity implements ITickable {
   }
 
   protected boolean isPoweredRedstone() {
-    return hasWorld() && world.isBlockLoaded(getPos()) ? world.isBlockIndirectlyGettingPowered(getPos()) > 0 : false;
+    return hasWorld() && world.isBlockLoaded(getPos()) ? world.getRedstonePowerFromNeighbors(getPos()) > 0 : false;
   }
 
   /**

--- a/src/main/java/com/enderio/core/common/fluid/BlockFluidEnder.java
+++ b/src/main/java/com/enderio/core/common/fluid/BlockFluidEnder.java
@@ -27,17 +27,17 @@ public abstract class BlockFluidEnder extends BlockFluidClassic {
   private float fogColorRed = 1f;
   private float fogColorGreen = 1f;
   private float fogColorBlue = 1f;
-  private final @Nonnull Material material;
+  private final @Nonnull Material fluidMaterial;
 
-  protected BlockFluidEnder(@Nonnull Fluid fluid, @Nonnull Material material, int fogColor) {
-    super(fluid, new MaterialLiquid(material.getMaterialMapColor()) {
+  protected BlockFluidEnder(@Nonnull Fluid fluid, @Nonnull Material fluidMaterial, int fogColor) {
+    super(fluid, new MaterialLiquid(fluidMaterial.getMaterialMapColor()) {
       // new Material for each liquid so neighboring different liquids render correctly and don't bleed into each other
       @Override
       public boolean blocksMovement() {
         return true; // so our liquids are not replaced by water
       }
     });
-    this.material = material;
+    this.fluidMaterial = fluidMaterial;
 
     // darken fog color to fit the fog rendering
     float dim = 1;
@@ -52,7 +52,7 @@ public abstract class BlockFluidEnder extends BlockFluidClassic {
   }
 
   protected void setNames(Fluid fluid) {
-    setUnlocalizedName(NullHelper.notnullF(fluid.getUnlocalizedName(), "encountered fluid without a name"));
+    setTranslationKey(NullHelper.notnullF(fluid.getUnlocalizedName(), "encountered fluid without a name"));
     setRegistryName("block_fluid_" + fluid.getName().toLowerCase(Locale.ENGLISH));
   }
 
@@ -83,7 +83,7 @@ public abstract class BlockFluidEnder extends BlockFluidClassic {
   @Override
   public Boolean isEntityInsideMaterial(@Nonnull IBlockAccess world, @Nonnull BlockPos blockpos, @Nonnull IBlockState iblockstate, @Nonnull Entity entity,
       double yToTest, @Nonnull Material materialIn, boolean testingHead) {
-    if (materialIn == material || materialIn == this.blockMaterial) {
+    if (materialIn == fluidMaterial || materialIn == this.material) {
       return Boolean.TRUE;
     }
     return super.isEntityInsideMaterial(world, blockpos, iblockstate, entity, yToTest, materialIn, testingHead);

--- a/src/main/java/com/enderio/core/common/inventory/EnderInventory.java
+++ b/src/main/java/com/enderio/core/common/inventory/EnderInventory.java
@@ -128,7 +128,7 @@ public class EnderInventory implements IItemHandler {
       if (entry.getValue() != null) {
         NBTTagCompound subTag = new NBTTagCompound();
         entry.getValue().writeToNBT(subTag);
-        if (!subTag.hasNoTags()) {
+        if (!subTag.isEmpty()) {
           tag.setTag(NullHelper.notnull(entry.getKey(), "Internal data corruption"), subTag);
         }
       }

--- a/src/main/java/com/enderio/core/common/tweaks/SlabRecipes.java
+++ b/src/main/java/com/enderio/core/common/tweaks/SlabRecipes.java
@@ -29,7 +29,7 @@ public class SlabRecipes extends Tweak {
 
   private static void addSlabRecipe(@Nonnull ItemStack stack, @Nonnull String slab) {
     ForgeRegistries.RECIPES.register(new ShapelessOreRecipe(null, stack, slab, slab)
-        .setRegistryName(slab + "_to_" + NullHelper.notnullM(stack.getItem().getRegistryName(), "found unregistered item").getResourcePath()));
+        .setRegistryName(slab + "_to_" + NullHelper.notnullM(stack.getItem().getRegistryName(), "found unregistered item").getPath()));
   }
 
   private static void registerSlabToBlock() {

--- a/src/main/java/com/enderio/core/common/util/CreativeTabsCustom.java
+++ b/src/main/java/com/enderio/core/common/util/CreativeTabsCustom.java
@@ -42,7 +42,7 @@ public class CreativeTabsCustom extends CreativeTabs {
   }
 
   @Override
-  public @Nonnull ItemStack getTabIconItem() {
+  public @Nonnull ItemStack createIcon() {
     return displayStack;
   }
 }

--- a/src/main/java/com/enderio/core/common/util/ForgeDirectionOffsets.java
+++ b/src/main/java/com/enderio/core/common/util/ForgeDirectionOffsets.java
@@ -10,7 +10,7 @@ public final class ForgeDirectionOffsets {
 
   static {
     for (EnumFacing dir : EnumFacing.values()) {
-      OFFSETS[dir.ordinal()] = new Vector3d(dir.getFrontOffsetX(), dir.getFrontOffsetY(), dir.getFrontOffsetZ());
+      OFFSETS[dir.ordinal()] = new Vector3d(dir.getXOffset(), dir.getYOffset(), dir.getZOffset());
     }
   }
 


### PR DESCRIPTION
Updated the forge mappings to use the final 1.12 mappings. Also renamed material in BlockFluidEnder to fluidMaterial to not intersect the parent field material in block that used to be named blockMaterial.