### PR TITLE
Allow to disable enchantment descriptions with a config option.

### DIFF
--- a/src/main/java/com/enderio/core/client/handlers/EnchantTooltipHandler.java
+++ b/src/main/java/com/enderio/core/client/handlers/EnchantTooltipHandler.java
@@ -6,6 +6,7 @@ import com.enderio.core.EnderCore;
 import com.enderio.core.api.common.enchant.IAdvancedEnchant;
 import com.enderio.core.common.Handlers.Handler;
 
+import com.enderio.core.common.config.ConfigHandler;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.util.text.TextFormatting;
@@ -17,6 +18,10 @@ public class EnchantTooltipHandler {
 
   @SubscribeEvent
   public static void handleTooltip(ItemTooltipEvent event) {
+    if (!ConfigHandler.showEnchantmentTooltips) {
+      return;
+    }
+
     if (event.getItemStack().hasTagCompound()) {
       Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(event.getItemStack());
 

--- a/src/main/java/com/enderio/core/common/config/ConfigHandler.java
+++ b/src/main/java/com/enderio/core/common/config/ConfigHandler.java
@@ -67,6 +67,11 @@ public class ConfigHandler extends AbstractConfigHandler implements ITweakConfig
   public static int showDurabilityTooltips = 1;
 
   @Config
+  @Comment("Show description for enchantments in tooltips.")
+  @NoSync
+  public static boolean showEnchantmentTooltips = true;
+
+  @Config
   @Comment("The way the game should have been made (Yes this is the fireworks thing).")
   public static boolean betterAchievements = false;
 


### PR DESCRIPTION
Since #96 still isn't fixed and [using resource packs just to disable the tooltips](https://github.com/SleepyTrousers/EnderIO/issues/4863#issuecomment-420287082) is a bit tricky (especially if someone uses non-English locale), i've added a config entry to disable enchantment description tooltips completely.