### PR TITLE
Fix amount drop in Auto Smelt Enchantment

### DIFF
--- a/src/main/java/com/enderio/core/common/handlers/AutoSmeltHandler.java
+++ b/src/main/java/com/enderio/core/common/handlers/AutoSmeltHandler.java
@@ -42,6 +42,8 @@ public class AutoSmeltHandler {
               if (!smeltingResult.isEmpty()) {
                 @Nonnull
                 ItemStack furnaceStack = smeltingResult.copy();
+                
+                furnaceStack.setCount(stack.getCount() * furnaceStack.getCount());
 
                 event.getDrops().set(i, furnaceStack);
 


### PR DESCRIPTION
Hello! I came across a problem with ExCompressum. If Compressed Gravel is broken with a Compressed Hammer (enchanted for auto-melting), 9 glasses should drop, but only one glass drop. This fixes this issue