### PR TITLE
Pulling in security patches from GTNewHorizons

### DIFF
--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -62,6 +62,10 @@ public class PacketConfigSync implements IMessage {
   @SuppressWarnings("unchecked")
   @Override
   public void fromBytes(ByteBuf buf) {
+    if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
+      return;
+    }
+    
     short len = buf.readShort();
     byte[] compressedBody = new byte[len];
 

--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -1,5 +1,8 @@
 package com.enderio.core.common.config;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -65,7 +68,7 @@ public class PacketConfigSync implements IMessage {
     if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
       return;
     }
-    
+
     short len = buf.readShort();
     byte[] compressedBody = new byte[len];
 

--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -1,7 +1,7 @@
 package com.enderio.core.common.config;
 
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.relauncher.Side;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.Side;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -3,11 +3,20 @@ package com.enderio.core.common.config;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 
 import com.enderio.core.common.util.NullHelper;
 import com.google.common.base.Throwables;
@@ -60,7 +69,8 @@ public class PacketConfigSync implements IMessage {
       compressedBody[i] = buf.readByte();
 
     try {
-      ObjectInputStream obj = new ObjectInputStream(new GZIPInputStream(new ByteArrayInputStream(compressedBody)));
+      ObjectInputStream obj = new ValidatingObjectInputStream(
+        new GZIPInputStream(new ByteArrayInputStream(compressedBody)));
       configValues = (Map<String, Object>) obj.readObject();
       obj.close();
     } catch (Exception e) {
@@ -80,4 +90,27 @@ public class PacketConfigSync implements IMessage {
       return null;
     }
   }
+
+  private static class ValidatingObjectInputStream extends ObjectInputStream {
+
+    private static final List<String> WHITELIST = Arrays
+      .asList("java.util.HashMap", "java.lang.Integer", "java.lang.Number", "java.lang.Boolean");
+
+        private static final Logger logger = LogManager.getLogger();
+        private static final Marker securityMarker = MarkerManager.getMarker("SuspiciousPackets");
+
+        private ValidatingObjectInputStream(InputStream in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+            String name = desc.getName();
+            if (!WHITELIST.contains(name)) {
+                logger.warn(securityMarker, "Received packet containing disallowed class: " + name);
+                throw new RuntimeException();
+            }
+            return super.resolveClass(desc);
+        }
+    }
 }


### PR DESCRIPTION
Fix authored by GTNewHorizons, pulling them in as they're fairly important to have.

https://github.com/GTNewHorizons/EnderCore/pull/9
https://github.com/GTNewHorizons/EnderCore/pull/16

Once this is merged, Ender IO 1.12.2 should have its minimum version pushed up to match this fix.