### PR TITLE
Pulling in security patches from GTNewHorizons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven { url = "http://files.minecraftforge.net/maven" }
+        maven { url = "https://maven.minecraftforge.net/" }
         maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
-    dependencies { classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT' }
+    dependencies {
+        classpath ('com.anatawa12.forge:ForgeGradle:1.2-1.1.+') {
+        changing = true
+    }
+}
 }
 
 apply plugin: 'forge'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -62,6 +62,10 @@ public class PacketConfigSync implements IMessage {
   @SuppressWarnings("unchecked")
   @Override
   public void fromBytes(ByteBuf buf) {
+    if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
+      return;
+    }
+
     short len = buf.readShort();
     byte[] compressedBody = new byte[len];
 

--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -1,5 +1,8 @@
 package com.enderio.core.common.config;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+
 import io.netty.buffer.ByteBuf;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
+++ b/src/main/java/com/enderio/core/common/config/PacketConfigSync.java
@@ -5,11 +5,20 @@ import io.netty.buffer.ByteBuf;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 
 import com.google.common.base.Throwables;
 
@@ -60,7 +69,8 @@ public class PacketConfigSync implements IMessage {
       compressedBody[i] = buf.readByte();
 
     try {
-      ObjectInputStream obj = new ObjectInputStream(new GZIPInputStream(new ByteArrayInputStream(compressedBody)));
+      ObjectInputStream obj = new ValidatingObjectInputStream(
+        new GZIPInputStream(new ByteArrayInputStream(compressedBody)));
       configValues = (Map<String, Object>) obj.readObject();
       obj.close();
     } catch (Exception e) {
@@ -80,4 +90,27 @@ public class PacketConfigSync implements IMessage {
       return null;
     }
   }
+
+  private static class ValidatingObjectInputStream extends ObjectInputStream {
+
+    private static final List<String> WHITELIST = Arrays
+      .asList("java.util.HashMap", "java.lang.Integer", "java.lang.Number", "java.lang.Boolean");
+
+        private static final Logger logger = LogManager.getLogger();
+        private static final Marker securityMarker = MarkerManager.getMarker("SuspiciousPackets");
+
+        private ValidatingObjectInputStream(InputStream in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+            String name = desc.getName();
+            if (!WHITELIST.contains(name)) {
+                logger.warn(securityMarker, "Received packet containing disallowed class: " + name);
+                throw new RuntimeException();
+            }
+            return super.resolveClass(desc);
+        }
+    }
 }


### PR DESCRIPTION
Fix authored by GTNewHorizons, pulling them in as they're fairly important to have.

https://github.com/GTNewHorizons/EnderCore/pull/9
https://github.com/GTNewHorizons/EnderCore/pull/16

Once this is merged, Ender IO 1.7.10 should have its minimum version pushed up to match this fix.